### PR TITLE
Create bypass YMusic link shortener.json

### DIFF
--- a/bypass YMusic shortener.json
+++ b/bypass YMusic shortener.json
@@ -1,0 +1,8 @@
+{
+  "YMusic ➔ Youtube": {
+    "regex": "^https:\/\/ymusic.io\/watch\\?v=",
+    "replacement": "https:\/\/youtu.be\/",
+    "automatic": "true",
+    "enabled": "true"
+  }
+}


### PR DESCRIPTION
When sharing a video link from the YMusic app, this will replace it with a proper youtube link bypassing the ymusic.io landing page