### PR TITLE
Create href-li.json

### DIFF
--- a/href-li.json
+++ b/href-li.json
@@ -1,0 +1,6 @@
+{
+  "Remove href.li from URL": {
+    "regex": "^https?:\/\/href.li\/\\?",
+    "replacement": ""
+  }
+}

--- a/href-li.json
+++ b/href-li.json
@@ -1,6 +1,6 @@
 {
   "Remove href.li from URL": {
-    "regex": "^https?:\/\/href.li\/\\?",
+    "regex": "^(https?:\/\/)?href.li\/\\?",
     "replacement": ""
   }
 }


### PR DESCRIPTION
Some websites (e.g. Tumblr, WordPress, Blogger) use href.li to stripe requests from their referrer header. There are reasons to avoid this practice (see https://news.ycombinator.com/item?id=26791530), specially since apps like urlChecker do it for you.