### PR TITLE
Twitter X

### DIFF
--- a/miscellaneous.json
+++ b/miscellaneous.json
@@ -1,5 +1,5 @@
-  {
-    "Bypass that Paywall": {
+{
+  "Bypass that Paywall": {
     "regex1": "^(https?):\/\/(\\S*)$",
     "regex": "^(?!.*(12ft.))(.*)",
     "replacement": "https:\/\/12ft.io\/$2",
@@ -15,4 +15,9 @@
     "regex": "^(?!.*:)",
     "replacement": "https:\/\/search.brave.com\/search?q=$0"
   },
+  "X to Twitter": {
+        "regex": "^https?:\/\/(?:[a-z0-9-]+\\.)*?x.com\/(.*)",
+        "replacement": "https:\/\/twitter.com\/$1",
+        "enabled": "true"
+  }
 }

--- a/privacy redirector.json
+++ b/privacy redirector.json
@@ -61,8 +61,8 @@
     "enabled": "true"
   },
   "Twitter to Nitter": {
-    "regex": "^https?:\\\/\\\/(www\\.|mobile\\.)?twitter\\.com\\\/(.*)",
-    "replacement": "https:\/\/farside.link\/nitter\/$2",
+    "regex": "^https?:\\\/\\\/(www\\.|mobile\\.)?(twitter|x)\\.com\\\/(.*)",
+    "replacement": "https:\/\/farside.link\/nitter\/$3",
     "enabled": "true"
   },
   "Twitter image to Nitter": {


### PR DESCRIPTION
Here are 2 rules I made:

1. Detect X as Twitter: For Nitter purposes, so X URLs can be changed to Nitter URLs
2. X to Twitter: Older versions of the Twitter app don't know that X is the new Twitter domain, this allows changing the domain easily so the Twitter app recognizes the URL as something it can open.